### PR TITLE
480 is a little small for some

### DIFF
--- a/res/values/custom_config.xml
+++ b/res/values/custom_config.xml
@@ -17,7 +17,7 @@ limitations under the License.
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
 
     <!-- maximum value for the custom display density -->
-    <integer name="display_density_max">480</integer>
+    <integer name="display_density_max">700</integer>
     <!-- minimum value for the custom display density -->
     <integer name="display_density_min">240</integer>
 


### PR DESCRIPTION
You may want this to be set higher for devices that have a higher density. For ex My g3 is 640 stock and in my experience some users like it there. The current config will not save anything above your max 480.
